### PR TITLE
src/main/java/duke/task/Task.java: add assert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,21 @@ repositories {
 dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.0'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.0'
+
+    String javaFxVersion = '17.0.7'
+
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
 }
 
 test {
@@ -34,7 +49,7 @@ test {
 
 application {
 //    mainClass.set("seedu.duke.Duke")
-    mainClass.set("duke.Duke")
+    mainClass.set("duke.Launcher")
 }
 
 shadowJar {

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -38,6 +38,7 @@ public class Task {
         String[] result = new String[2];
         result[0] = this.description;
         result[1] = this.isDone ? "Y" : "N";
+        assert result[1].equals("Y") || result[1].equals("N") : "The isDone will either be 'Y' or 'N'";
         return result;
     }
 


### PR DESCRIPTION
The field isDone is only possible to be 'Y' which is yes or 'N' which is no.

Java assert is used to ensure that it can only be 'Y' or 'N'.

Java assert is used instead of throwing exception because the previous line assigns 'Y' or 'N' to isDone, and hence if isDone is not 'Y' or 'N' at this point, that must be some mistakes made by programmer, which is suitable to be handled with assertion.